### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ticketml [![Build Status](https://travis-ci.org/lukegb/ticketml.svg?branch=master)](https://travis-ci.org/lukegb/ticketml) [![PyPI Version](https://pypip.in/version/ticketml/badge.svg?style=flat)](https://pypi.python.org/pypi/ticketml)
+# ticketml [![Build Status](https://travis-ci.org/lukegb/ticketml.svg?branch=master)](https://travis-ci.org/lukegb/ticketml) [![PyPI Version](https://img.shields.io/pypi/v/ticketml.svg?style=flat)](https://pypi.python.org/pypi/ticketml)
 A small XML-based markup language for tickets
 
 Why?


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ticketml))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ticketml`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.